### PR TITLE
Add support of Code Flow Authorization

### DIFF
--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -278,7 +278,8 @@ impl Debug for CodeAuthenticator {
 
 impl CodeAuthenticator {
     /// Creates a new Authenticator by Code Flow
-    /// The "client_secret" for non-confidential clients (Installed APPs) is an empty string.
+    /// 
+    /// Note: The "client_secret" for non-confidential clients (Installed APPs) is an empty string.
     #[allow(clippy::new_ret_no_self)]
     pub fn new<S: Into<String>>(
         client_id: S,

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -43,6 +43,9 @@ pub trait Authenticator: Clone + Send + Sync + Debug {
     fn get_refresh_token(&self) -> Option<String>;
 }
 
+#[async_trait]
+pub trait Authorized: Authenticator {}
+
 /// AnonymousAuthenticator
 #[derive(Clone, Default)]
 pub struct AnonymousAuthenticator;
@@ -239,6 +242,9 @@ impl Authenticator for PasswordAuthenticator {
         Option::None
     }
 }
+
+#[async_trait]
+impl Authorized for PasswordAuthenticator {}
 
 #[derive(Clone)]
 pub struct CodeAuthenticator {
@@ -447,3 +453,6 @@ impl Authenticator for CodeAuthenticator {
         self.refresh_token.to_owned()            
     }
 }
+
+#[async_trait]
+impl Authorized for CodeAuthenticator {}

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -16,6 +16,12 @@ pub struct TokenResponseData {
     pub expires_in: u64,
     pub scope: String,
     pub token_type: String,
+    #[serde(default = "default_response")]
+    pub refresh_token: String,
+}
+
+fn default_response() -> String {
+    "".to_string()
 }
 
 #[async_trait]
@@ -25,12 +31,16 @@ pub trait Authenticator: Clone + Send + Sync + Debug {
     async fn login(&mut self, client: &Client, user_agent: &str) -> Result<bool, Error>;
     /// Releases the token back to Reddit
     async fn logout(&mut self, client: &Client, user_agent: &str) -> Result<(), Error>;
+    /// true if successful
+    async fn token_refresh(&mut self, client: &Client, user_agent: &str) -> Result<bool, Error>;
     /// Header Values required for auth
     fn headers(&self, headers: &mut HeaderMap);
     /// Supports OAuth
     fn oauth(&self) -> bool;
     /// Does the Token need refresh
     fn needs_token_refresh(&self) -> bool;
+    /// Returns refresh token
+    fn get_refresh_token(&self) -> Option<String>;
 }
 
 /// AnonymousAuthenticator
@@ -53,6 +63,10 @@ impl Authenticator for AnonymousAuthenticator {
     async fn logout(&mut self, _client: &Client, _user_agent: &str) -> Result<(), Error> {
         Ok(())
     }
+    /// Returns true because it is anonymous
+    async fn token_refresh(&mut self, _client: &Client, _user_agent: &str) -> Result<bool, Error> {
+        Ok(true)
+    }
     /// Does Nothing
     fn headers(&self, _headers: &mut HeaderMap) {}
     /// False because not logged in
@@ -62,6 +76,10 @@ impl Authenticator for AnonymousAuthenticator {
     /// Always false
     fn needs_token_refresh(&self) -> bool {
         false
+    }
+    /// Always None
+    fn get_refresh_token(&self) -> Option<String> {
+        Option::None
     }
 }
 
@@ -189,6 +207,10 @@ impl Authenticator for PasswordAuthenticator {
         self.expiration_time = None;
         Ok(())
     }
+    /// Returns true if successful
+    async fn token_refresh(&mut self, client: &Client, user_agent: &str) -> Result<bool, Error> {
+        self.login(client, user_agent).await
+    }
     /// headers
     fn headers(&self, headers: &mut HeaderMap) {
         headers.insert(
@@ -211,5 +233,217 @@ impl Authenticator for PasswordAuthenticator {
         } else {
             i >= self.expiration_time.unwrap()
         }
+    }
+    /// Always None
+    fn get_refresh_token(&self) -> Option<String> {
+        Option::None
+    }
+}
+
+#[derive(Clone)]
+pub struct CodeAuthenticator {
+    /// Token
+    pub token: Option<String>,
+    /// When does it expire
+    pub expiration_time: Option<u128>,
+    /// Refresh token
+    pub refresh_token: Option<String>,
+    /// Client ID
+    client_id: String,
+    /// Client Secret
+    client_secret :String,
+    /// Authorization code
+    authorization_code: String,
+    /// Redirect URI 
+    redirect_uri: String,
+}
+
+impl Debug for CodeAuthenticator {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "[CodeAuthenticator] Token Defined: {} Expires At {} And Refrsh Token Defined: {}",
+            self.token.is_some(),
+            self.expiration_time.unwrap_or(0),
+            self.refresh_token.is_some()
+        )
+    }
+}
+
+impl CodeAuthenticator {
+    /// Creates a new Authenticator by Code Flow
+    /// The "client_secret" for non-confidential clients (Installed APPs) is an empty string.
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new<S: Into<String>>(
+        client_id: S,
+        client_secret: S,
+        authorization_code: S,
+        redirect_uri: S,
+    ) -> CodeAuthenticator {
+        CodeAuthenticator {
+            token: None,
+            expiration_time: None,
+            refresh_token: None,
+            client_id: client_id.into(),
+            client_secret: client_secret.into(),
+            authorization_code: authorization_code.into(),
+            redirect_uri: redirect_uri.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl Authenticator for CodeAuthenticator {
+    /// Logs in
+    async fn login(&mut self, client: &Client, user_agent: &str) -> Result<bool, Error> {
+        let url = "https://www.reddit.com/api/v1/access_token";
+        let body = format!(
+            "grant_type=authorization_code&code={}&redirect_uri={}",
+            &self.authorization_code.trim_end_matches("#_"), &self.redirect_uri
+        );
+        let mut header = HeaderMap::new();
+        header.insert(
+            AUTHORIZATION,
+            HeaderValue::from_str(&*format!(
+                "Basic {}",
+                base64::encode(format!(
+                    "{}:{}",
+                    self.client_id.to_owned(),
+                    self.client_secret.to_owned()
+                ))
+            ))
+            .unwrap(),
+        );
+        header.insert(USER_AGENT, HeaderValue::from_str(user_agent).unwrap());
+        header.insert(
+            CONTENT_TYPE,
+            HeaderValue::from_str("application/x-www-form-urlencoded").unwrap(),
+        );
+        let response = client
+            .post(url)
+            .body(Body::from(body))
+            .headers(header)
+            .send()
+            .await
+            .map_err(InternalError::from)?;
+        response.status().into_result()?;
+
+        let token = response.text().await?;
+        let token: TokenResponseData = serde_json::from_str(token.as_str())?;
+        self.token = Some(token.access_token);
+        let x = token.expires_in * 1000;
+        let x1 = (x as u128)
+            + SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_millis();
+        self.expiration_time = Some(x1);
+        if !token.refresh_token.is_empty() {
+            self.refresh_token = Some(token.refresh_token);
+        }        
+        return Ok(true);
+    }
+    /// Logs out
+    async fn logout(&mut self, client: &Client, user_agent: &str) -> Result<(), Error> {
+        let url = "https://www.reddit.com/api/v1/revoke_token";
+        let body: String;
+        if self.refresh_token.is_none() {
+            body = format!("token={}&token_type_hint=access_token", &self.token.to_owned().unwrap());
+        } else {
+            body = format!("token={}&token_type_hint=refresh_token", &self.refresh_token.to_owned().unwrap());
+        }
+
+        let mut header = HeaderMap::new();
+        header.insert(USER_AGENT, HeaderValue::from_str(user_agent).unwrap());
+        header.insert(
+            CONTENT_TYPE,
+            HeaderValue::from_str("application/x-www-form-urlencoded").unwrap(),
+        );
+        let response = client
+            .post(url)
+            .body(Body::from(body))
+            .headers(header)
+            .send()
+            .await?;
+        response.status().into_result()?;
+        self.token = None;
+        self.expiration_time = None;
+        self.refresh_token = None;
+        Ok(())
+    }
+    /// Returns true if successful
+    async fn token_refresh(&mut self, client: &Client, user_agent: &str) -> Result<bool, Error> {
+        let url = "https://www.reddit.com/api/v1/access_token";
+        let body = format!(
+            "grant_type=refresh_token&refresh_token={}",
+            &self.refresh_token.to_owned().unwrap()
+        );
+        let mut header = HeaderMap::new();
+        header.insert(
+            AUTHORIZATION,
+            HeaderValue::from_str(&*format!(
+                "Basic {}",
+                base64::encode(format!(
+                    "{}:",
+                    self.client_id.to_owned()
+                ))
+            ))
+            .unwrap(),
+        );
+        header.insert(USER_AGENT, HeaderValue::from_str(user_agent).unwrap());
+        header.insert(
+            CONTENT_TYPE,
+            HeaderValue::from_str("application/x-www-form-urlencoded").unwrap(),
+        );
+        let response = client
+            .post(url)
+            .body(Body::from(body))
+            .headers(header)
+            .send()
+            .await
+            .map_err(InternalError::from)?;
+        response.status().into_result()?;
+
+        let token = response.text().await?;
+        let token: TokenResponseData = serde_json::from_str(token.as_str())?;
+        self.token = Some(token.access_token);
+        let x = token.expires_in * 1000;
+        let x1 = (x as u128)
+            + SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_millis();
+        self.expiration_time = Some(x1);
+        return Ok(true);
+    }
+    /// headers
+    fn headers(&self, headers: &mut HeaderMap) {
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_str(&*format!("Bearer {}", self.token.to_owned().unwrap())).unwrap(),
+        );
+    }
+    /// True
+    fn oauth(&self) -> bool {
+        true
+    }
+    /// Validates Time
+    fn needs_token_refresh(&self) -> bool {
+        let i = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis();
+        if self.refresh_token.is_some() {
+            if self.expiration_time.is_none() {
+                true
+            } else {
+                i >= self.expiration_time.unwrap()
+            }
+        } else {
+            false
+        }       
+    }
+    fn get_refresh_token(&self) -> Option<String> {
+        self.refresh_token.to_owned()            
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -331,6 +331,26 @@ impl<A: Authorized> Client<A> {
         Ok(Me { client: self, me })
     }
     /// Gets the Refresh Token if exist
+    /// 
+    /// Note: Refresh Token only will be exist when using CodeAuthenticator with an Permanent Duration Authorization Code.
+    /// ```no_run
+    /// #[tokio::main]
+    /// async fn main() ->anyhow::Result<()>{
+    ///    use std::env;
+    /// use log::LevelFilter;
+    ///    use rraw::auth::{ CodeAuthenticator};
+    ///    use rraw::Client;
+    ///   env_logger::builder().is_test(true).filter_level(LevelFilter::Trace).try_init();
+    ///    let client = Client:: login(CodeAuthenticator::new(env::var("CLIENT_ID")?,env::var("CLIENT_SECRET")?,env::var("CODE")?,env::var("REDIRECT_URI")?), "RRAW Test (by u/KingTuxWH)").await?;
+    ///    let refresh_token = client.refresh_token();
+    ///    if refresh_token.is_some() {
+    ///        println!("Refresh Token Is: {}", refresh_token.unwrap());
+    ///    } else {
+    ///        println!("Refresh Token Not Exist!");
+    ///    }
+    ///    Ok(())
+    /// }
+    /// ```
     pub fn refresh_token(&self) -> Option<String> {
         self.refresh_token.to_owned()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -333,6 +333,7 @@ impl<A: Authorized> Client<A> {
     /// Gets the Refresh Token if exist
     /// 
     /// Note: Refresh Token only will be exist when using CodeAuthenticator with an Permanent Duration Authorization Code.
+    /// The Refresh Token must be stored in a secure manner such as using the platform's Secret/Keyring service for future use.
     /// ```no_run
     /// #[tokio::main]
     /// async fn main() ->anyhow::Result<()>{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ use reqwest::header::HeaderMap;
 use reqwest::{Body, Client as ReqwestClient, ClientBuilder, Response};
 use serde::de::DeserializeOwned;
 
-use crate::auth::{Authenticator, PasswordAuthenticator};
+use crate::auth::{Authenticator, Authorized};
 use crate::error::http_error::IntoResult;
 use crate::error::internal_error::InternalError;
 use crate::error::Error;
@@ -311,7 +311,7 @@ impl<A: Authenticator> Client<A> {
     }
 }
 
-impl Client<PasswordAuthenticator> {
+impl<A: Authorized> Client<A> {
     /// Gets the User Inbox Struct
     /// ```no_run
     /// #[tokio::main]
@@ -326,7 +326,7 @@ impl Client<PasswordAuthenticator> {
     ///    Ok(())
     /// }
     /// ```
-    pub async fn me(&self) -> Result<Me<'_>, Error> {
+    pub async fn me(&self) -> Result<Me<'_, A>, Error> {
         let me: MeResponse = self.get_json("/api/v1/me", true).await?;
         Ok(Me { client: self, me })
     }

--- a/src/subreddit/mod.rs
+++ b/src/subreddit/mod.rs
@@ -5,7 +5,7 @@ use reqwest::Body;
 
 use crate::submission::response::SubmissionsResponse;
 use crate::submission::SubmissionRetriever;
-use crate::{Client, PasswordAuthenticator};
+use crate::{Client, Authorized};
 
 use crate::auth::Authenticator;
 use crate::error::Error;
@@ -50,7 +50,7 @@ impl<'a, A: Authenticator> Subreddit<'a, A> {
     }
 }
 
-impl<'a> Subreddit<'a, PasswordAuthenticator> {
+impl<'a, A: Authorized> Subreddit<'a, A> {
     /// Adds a friend to the subreddit
     pub async fn add_friend(&self, username: String, typ: FriendType) -> Result<Friend, Error> {
         trace!(

--- a/src/user/me.rs
+++ b/src/user/me.rs
@@ -1,4 +1,4 @@
-use crate::auth::PasswordAuthenticator;
+use crate::auth::Authorized;
 use crate::comments::response::CommentsResponse;
 use crate::error::Error;
 use crate::message::response::MessageListing;
@@ -15,12 +15,12 @@ use crate::user::response::MeResponse;
 use crate::utils::options::FeedOption;
 
 /// The User Object for Reddit
-pub struct Me<'a> {
-    pub(crate) client: &'a Client<PasswordAuthenticator>,
+pub struct Me<'a, A: Authorized> {
+    pub(crate) client: &'a Client<A>,
     pub me: MeResponse,
 }
 
-impl<'a> Me<'a> {
+impl<'a, A: Authorized> Me<'a, A> {
     /// For blocking the author of a thing via inbox. - Reddit API
     pub async fn block_author(&self, full_name: FullName) -> Result<Friend, Error> {
         let string = "/api/block";

--- a/tests/me.rs
+++ b/tests/me.rs
@@ -14,11 +14,11 @@ mod me_tests {
             println!("Logger Failed to Init Error: {}", error);
         }
     }
-    async fn create_client() -> anyhow::Result<Client<PasswordAuthenticator>> {
+    async fn create_client_by_pass() -> anyhow::Result<Client<PasswordAuthenticator>> {
         dotenv::dotenv()?;
         let arc = PasswordAuthenticator::new(
-            std::env::var("CLIENT_KEY")?.as_str(),
-            std::env::var("CLIENT_SECRET")?.as_str(),
+            std::env::var("CLIENT_KEY_BY_PASS")?.as_str(),
+            std::env::var("CLIENT_SECRET_BY_PASS")?.as_str(),
             std::env::var("REDDIT_USER")?.as_str(),
             std::env::var("PASSWORD")?.as_str(),
         );
@@ -26,9 +26,9 @@ mod me_tests {
     }
     #[ignore]
     #[tokio::test]
-    async fn me_test() -> anyhow::Result<()> {
+    async fn me_test_by_pass() -> anyhow::Result<()> {
         init();
-        let client = create_client().await?;
+        let client = create_client_by_pass().await?;
 
         let me = client.me().await;
 
@@ -42,9 +42,9 @@ mod me_tests {
     }
     #[ignore]
     #[tokio::test]
-    async fn test_inbox() -> anyhow::Result<()> {
+    async fn test_inbox_by_pass() -> anyhow::Result<()> {
         init();
-        let client = create_client().await?;
+        let client = create_client_by_pass().await?;
 
         let me = client.me().await?;
 


### PR DESCRIPTION
In explaining the reason for the commit d58b689fc662ba0512f3ea10259dbf09700517c8  changes, I must say that I have recently started to learn and using Rust, hence I defined Authorized trait so that maybe it can be used later.

Also after merging this, I open another MR to add Authorization by Refresh Token, And I can think of two ways to implement it, which I will say in the comments.